### PR TITLE
Shorten and capitalize tab title to avoid overflow

### DIFF
--- a/views/partials/head.njk
+++ b/views/partials/head.njk
@@ -5,7 +5,7 @@
 
 <meta name='viewport' content='width = device-width, initial-scale = 1'>
 
-<title>Spluff | Shuffle your Spotify playlists</title>
+<title>Spluff | Shuffle Your Playlists</title>
 
 <link rel='icon' href='/resources/favicon.svg'>
 <link rel='apple-touch-icon' href='/resources/favicon.png'>


### PR DESCRIPTION
Shorten and capitalize tab title to avoid overflow